### PR TITLE
Fix deprecation warning

### DIFF
--- a/data/dbConnectors.js
+++ b/data/dbConnectors.js
@@ -5,7 +5,7 @@ import Sequelize from 'sequelize';
 
 // Mongo connection
 mongoose.Promise = global.Promise;
-mongoose.connect('mongodb://localhost/friends', {});
+mongoose.connect('mongodb://localhost/friends', { useNewUrlParser: true });
 
 const friendsSchema = new mongoose.Schema({
   firstName: {


### PR DESCRIPTION
Fix the deprecation warning:
```
DeprecationWarning: current URL string parser is deprecated, and will be removed in a future version. To use the new parser, pass option { useNewUrlParser: true } to MongoClient.connect.
```